### PR TITLE
Add converter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:2.7
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+
+COPY data/ /tmp/data/
+COPY scripts/ /tmp/scripts/
+COPY scanomatic/ /tmp/scanomatic/
+COPY setup.py /tmp/setup.py
+COPY setup_tools.py /tmp/setup_tools.py
+
+RUN cd /tmp && python setup.py install --default
+COPY converter.py /app/
+WORKDIR /app
+CMD ./converter.py

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Scan-o-matic project converted 
+# Scan-o-matic project converted
 
 1. Place all projects you wish to migrate in `/tmp/SoM/`
 
@@ -7,3 +7,7 @@ python 3 version of projects to the old python 2.7 version
 and contents of files will be overwritten.
 
 2. Run `docker-compose up`
+
+The script is designed to ignore already converted files,
+so it should be safe to run multiple times on the same
+project.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Scan-o-matic project converted 
+
+1. Place all projects you wish to migrate in `/tmp/SoM/`
+
+**NOTE**: There's no way to migrate back from the
+python 3 version of projects to the old python 2.7 version
+and contents of files will be overwritten.
+
+2. Run `docker-compose up`

--- a/converter.py
+++ b/converter.py
@@ -20,31 +20,35 @@ def find_files(directory, pattern):
                 yield filename
 
 
-l = Logger('Converter')
+logger = Logger('Converter')
 BASE_DIR = '/projects'
-p = Paths()
+paths = Paths()
 
 for file_type, pattern, loader, processor in (
     (
         'project compilations',
-        p.project_compilation_pattern.format('*'),
+        paths.project_compilation_pattern.format('*'),
         CompileImageAnalysisFactory.serializer.load,
         lambda data: sorted(data, key=lambda e: e.image.index),
     ),
     (
         'project compilation instructions',
-        p.project_compilation_instructions_pattern.format('*'),
+        paths.project_compilation_instructions_pattern.format('*'),
         CompileProjectFactory.serializer.load_first,
         None,
     ),
 ):
-    l.info('Converting all {} in {}'.format(file_type, BASE_DIR))
+    logger.info('Converting all {} in {}'.format(file_type, BASE_DIR))
     n = 0
     for fname in find_files(BASE_DIR, pattern):
         try:
             with open(fname) as fh:
                 if json.load(fh):
-                    l.info("Skipping {} because seems already converted".format(fname))
+                    logger.info(
+                        'Skipping {} because seems already converted'.format(
+                            fname,
+                        ),
+                    )
                     continue
         except ValueError:
             pass
@@ -52,7 +56,10 @@ for file_type, pattern, loader, processor in (
         data = loader(fname)
         if processor is not None:
             data = processor(data)
-        l.info('Converting {} ({} entries)'.format(fname, len(data) if isinstance(data, list) else 1))
+        logger.info('Converting {} ({} entries)'.format(
+            fname,
+            len(data) if isinstance(data, list) else 1,
+        ))
         jsonizer.dump(data, fname)
         n += 1
-    l.info('Converted {} {} files'.format(n, file_type))
+    logger.info('Converted {} {} files'.format(n, file_type))

--- a/converter.py
+++ b/converter.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+import os
+import fnmatch
+import json
+from scanomatic.io import jsonizer
+from scanomatic.models.factories.compile_project_factory import (
+    CompileImageAnalysisFactory,
+    CompileProjectFactory,
+)
+from scanomatic.io.paths import Paths
+from scanomatic.io.logger import Logger
+
+
+
+def find_files(directory, pattern):
+    for root, dirs, files in os.walk(directory):
+        for basename in files:
+            if fnmatch.fnmatch(basename, pattern):
+                filename = os.path.join(root, basename)
+                yield filename
+
+
+l = Logger('Converter')
+BASE_DIR = '/projects'
+p = Paths()
+
+for file_type, pattern, loader, processor in (
+    (
+        'project compilations',
+        p.project_compilation_pattern.format('*'),
+        CompileImageAnalysisFactory.serializer.load,
+        lambda data: sorted(data, key=lambda e: e.image.index),
+    ),
+    (
+        'project compilation instructions',
+        p.project_compilation_instructions_pattern.format('*'),
+        CompileProjectFactory.serializer.load_first,
+        None,
+    ),
+):
+    l.info('Converting all {} in {}'.format(file_type, BASE_DIR))
+    n = 0
+    for fname in find_files(BASE_DIR, pattern):
+        try:
+            with open(fname) as fh:
+                if json.load(fh):
+                    l.info("Skipping {} because seems already converted".format(fname))
+                    continue
+        except ValueError:
+            pass
+
+        data = loader(fname)
+        if processor is not None:
+            data = processor(data)
+        l.info('Converting {} ({} entries)'.format(fname, len(data) if isinstance(data, list) else 1))
+        jsonizer.dump(data, fname)
+        n += 1
+    l.info('Converted {} {} files'.format(n, file_type))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2'
+
+services:
+  som-converter:
+    image: phenomique/convert-project:latest
+    build: .
+    volumes:
+      - /tmp/SoM:/projects

--- a/get_installed_version.py
+++ b/get_installed_version.py
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-from importlib import import_module
-
-som = import_module('scanomatic')
-print 'Scan-o-Matic {0}, {1}'.format(som.get_version(), som.get_branch())


### PR DESCRIPTION
Creates the converter script that allows for migration of python 2.7 version of scan-o-matic serialized project to the new python 3 version of how projects are serialized.