### PR TITLE
handle dataclass type for Pheno settings

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -70,8 +70,11 @@ for file_type, pattern, loader, processor, new_ext in (
         paths.phenotypes_extraction_params,
         np.load,
         lambda data: {
-            PHENOTYPE_PARAMS[i].name: PHENOTYPE_PARAMS[i].processor(p)
-            for i, p in enumerate(data)
+            "__DATACLASS__": "PhenotyperSettings",
+            "__CONTENT__": {
+                PHENOTYPE_PARAMS[i].name: PHENOTYPE_PARAMS[i].processor(p)
+                for i, p in enumerate(data)
+            },
         },
         ".json",
     ),


### PR DESCRIPTION
This PR tweaks the conversion of phenotyper settings, to that they are ready to be read into a dataclass object in SoM-SA.

`phenotype_params.json`:
```json
{
    "__CONTENT__": {
        "gaussian_filter_sigma": 1.5,
        "linear_regression_size": 5,
        "median_kernel_size": 5,
        "no_growth_monotonicity_threshold": 0.6,
        "no_growth_pop_doublings_threshold": 1.0,
        "phenotypes_inclusion": {
            "__CONTENT__": "Trusted",
            "__ENUM__": "PhenotypeDataType"
        }
    },
    "__DATACLASS__": "PhenotyperSettings"
}

```