### PR TITLE
fixture config

### DIFF
--- a/scanomatic/io/fixtures.py
+++ b/scanomatic/io/fixtures.py
@@ -66,9 +66,9 @@ class FixtureSettings(object):
 
         paths = Paths()
 
-        if self.model.orentation_mark_path:
-            marker_paths = (self.model.orentation_mark_path,
-                         os.path.join(paths.images, os.path.basename(self.model.orentation_mark_path)),
+        if self.model.orientation_mark_path:
+            marker_paths = (self.model.orientation_mark_path,
+                         os.path.join(paths.images, os.path.basename(self.model.orientation_mark_path)),
                          paths.marker)
         else:
             marker_paths = (paths.marker,)

--- a/scanomatic/models/factories/fixture_factories.py
+++ b/scanomatic/models/factories/fixture_factories.py
@@ -91,11 +91,11 @@ class FixtureFactory(AbstractModelFactory):
         for (old_name, new_name) in [("grayscale_indices", "grayscale_targets"),
                                      ("mark_X", "orientation_marks_x"),
                                      ("mark_Y", "orientation_marks_y"),
+                                     ("orentation_mark_path", "orientation_mark_path"),
                                      ("Image Shape", "shape"), ("Scale", "coordinates_scale"),
                                      ("File", "path"), ("Time", "time")]:
 
             rename_setting(settings, old_name, new_name)
-
         if "plates" not in settings or not settings["plates"]:
             settings["plates"] = []
 

--- a/scanomatic/models/fixture_models.py
+++ b/scanomatic/models/fixture_models.py
@@ -40,7 +40,7 @@ class FixtureModel(model.Model):
         self.shape = shape
         self.coordinates_scale = coordinates_scale
         self.plates = plates
-        self.orentation_mark_path = orientation_mark_path
+        self.orientation_mark_path = orientation_mark_path
         self.scale = scale
 
         super(FixtureModel, self).__init__()


### PR DESCRIPTION
In this PR we intend to fix an old scanomatic type (orentation_mark_path -> orientation_mark_path).
I have tried to convert Payams files and using this change.
However there is no orentation_mark_path stuff in the old format fixture.config file,
but in the new one there is now :

  - "orientation_mark_path": "" 
 
and without this change:

  - "orentation_mark_path": ""

 
Resolves #9 